### PR TITLE
udev: ignore whole disc devices, trigger only for partitions

### DIFF
--- a/90-usbmount.rules
+++ b/90-usbmount.rules
@@ -1,7 +1,7 @@
 # Rules for USBmount -*- conf -*-
 
-KERNEL=="sd*", DRIVERS=="sbp2",		ACTION=="add",	PROGRAM="/bin/systemd-escape -p --template=usbmount@.service $env{DEVNAME}", ENV{SYSTEMD_WANTS}+="%c"
-KERNEL=="sd*", SUBSYSTEMS=="usb",	ACTION=="add",	PROGRAM="/bin/systemd-escape -p --template=usbmount@.service $env{DEVNAME}", ENV{SYSTEMD_WANTS}+="%c"
+KERNEL=="sd*[0-9]*", DRIVERS=="sbp2",		ACTION=="add",	PROGRAM="/bin/systemd-escape -p --template=usbmount@.service $env{DEVNAME}", ENV{SYSTEMD_WANTS}+="%c"
+KERNEL=="sd*[0-9]*", SUBSYSTEMS=="usb",	ACTION=="add",	PROGRAM="/bin/systemd-escape -p --template=usbmount@.service $env{DEVNAME}", ENV{SYSTEMD_WANTS}+="%c"
 KERNEL=="ub*", SUBSYSTEMS=="usb",	ACTION=="add",	PROGRAM="/bin/systemd-escape -p --template=usbmount@.service $env{DEVNAME}", ENV{SYSTEMD_WANTS}+="%c"
-KERNEL=="sd*",				ACTION=="remove",	RUN+="/usr/share/usbmount/usbmount remove"
+KERNEL=="sd*[0-9]*",				ACTION=="remove",	RUN+="/usr/share/usbmount/usbmount remove"
 KERNEL=="ub*",				ACTION=="remove",	RUN+="/usr/share/usbmount/usbmount remove"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,8 @@
+usbmount (0.0.24+1rpi) unstable; urgency=low
+  * modify udev rules to ignore whole disc devices, process the partition devices only
+
+ -- Jools Wills <buzz@exotica.org.uk>  Fri, 15 Jan 2021 06:55:16 +0000
+
 usbmount (0.0.24) unstable; urgency=medium
 
   * added systemd service and adjusted udev rules based on https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=774149#177


### PR DESCRIPTION
Gets rid of the errors shown by trying to mount `/dev/sdX`.